### PR TITLE
Compilation Databases Support

### DIFF
--- a/include/builder.h
+++ b/include/builder.h
@@ -237,6 +237,10 @@ struct BuilderOptions {
 	// If this is set to true, then a code build will NOT happen.
 	// If you don't use Visual Studio then ignore this.
 	bool						generate_solution;
+	
+	// Do you want to generate a compilation_commands.json for Clang tooling?
+	// If true, the file will be generated IF the build is successful. 
+	bool						generate_compilation_database;
 };
 
 static void add_build_config_unique( BuildConfig* config, std::vector<BuildConfig>& out_configs );

--- a/scripts/build_tests.bat
+++ b/scripts/build_tests.bat
@@ -47,7 +47,7 @@ if /I [%config%]==[debug] (
 	set defines=!defines! -D_DEBUG -DBUILDER_PROGRAM_NAME=\"!program_name!\"
 ) else if /I [%config%]==[release] (
 	set program_name=builder
-	set defines=!defines! -DNDEBUG _DBUILDER_PROGRAM_NAME=\"!program_name!\"
+	set defines=!defines! -DNDEBUG -DBUILDER_PROGRAM_NAME=\"!program_name!\"
 )
 
 set includes=-Isrc/core/include

--- a/src/backend_clang.cpp
+++ b/src/backend_clang.cpp
@@ -230,128 +230,50 @@ static void Clang_Shutdown( compilerBackend_t* backend ) {
 	backend->data = NULL;
 }
 
-static bool8 Clang_CompileSourceFile( compilerBackend_t* backend, const char* sourceFile, BuildConfig* config ) {
+static bool8 Clang_CompileSourceFile(
+	compilerBackend_t* backend,
+	buildContext_t* buildContext,
+	BuildConfig* config,
+	compilationCommandArchetype_t& cmdArchetype,
+	const char* sourceFile,
+	bool recordCompilation )
+{
 	assert( backend );
 	assert( sourceFile );
 
 	clangState_t* clangState = cast( clangState_t*, backend->data );
 
-	bool8 isClang = string_ends_with( clangState->compilerPath.data, "clang" ) || string_ends_with( clangState->compilerPath.data, "clang++" );
-	bool8 isGCC = string_ends_with( clangState->compilerPath.data, "gcc" ) || string_ends_with( clangState->compilerPath.data, "g++" );
-
 	const char* sourceFileNoPath = path_remove_path_from_file( sourceFile );
-
 	const char* intermediatePath = tprintf( "%s%c%s", config->binary_folder.c_str(), PATH_SEPARATOR, INTERMEDIATE_PATH );
-	const char* intermediateFilename = tprintf( "%s%c%s.o", intermediatePath, PATH_SEPARATOR, sourceFileNoPath );
-
 	const char* depFilename = tprintf( "%s%c%s.d", intermediatePath, PATH_SEPARATOR, sourceFileNoPath );
+	
+	Array<const char*> finalArgs = cmdArchetype.baseArgs;
 
-	Array<const char*>& args = clangState->args;
-	args.reserve(
-		1 +	// clang/gcc
-		1 +	// -shared/-lib
-		1 +	// -c
-		1 +	// std=
-		1 +	// symbols
-		1 +	// optimisation
-		1 +	// -o
-		1 +	// intermediate filename
-		3 +	// -MD -MF <filename>
-		1 +	// source file
-		config->defines.size() +
-		config->additional_includes.size() +
-		config->additional_lib_paths.size() +
-		config->additional_libs.size() +
-		config->warning_levels.size() +
-		config->ignore_warnings.size()
-	);
-
-	args.reset();
-
-	args.add( clangState->compilerPath.data );
-
-	args.add( "-c" );
-
-	if ( config->language_version != LANGUAGE_VERSION_UNSET ) {
-		args.add( LanguageVersionToCompilerArg( config->language_version ) );
+	// Fill up remaining arguments
+	
+	// Dependency Flags/File
+	For( u64, flagIndex, 0, cmdArchetype.dependencyFlags.count) {
+		finalArgs.add( cmdArchetype.dependencyFlags[flagIndex] );
 	}
+	finalArgs.add( tprintf( "%s%c%s.d", intermediatePath, PATH_SEPARATOR, sourceFileNoPath ) );
 
-	if ( !config->remove_symbols ) {
-		args.add( "-g" );
-	}
+	// Output Flag/File
+	finalArgs.add( cmdArchetype.outputFlag );
+	finalArgs.add( tprintf( "%s%c%s.o", intermediatePath, PATH_SEPARATOR, path_remove_file_extension( sourceFileNoPath ) ) );
 
-	args.add( OptimizationLevelToCompilerArg( config->optimization_level ) );
-
-	args.add( "-o" );
-	args.add( intermediateFilename );
-
-	args.add( "-MMD" );			// generate the dependency file
-	args.add( "-MF" );			// set the name of the dependency file to...
-	args.add( depFilename );	// ...this
-
-	args.add( sourceFile );
-
-	For ( u32, defineIndex, 0, config->defines.size() ) {
-		args.add( tprintf( "-D%s", config->defines[defineIndex].c_str() ) );
-	}
-
-	For ( u32, includeIndex, 0, config->additional_includes.size() ) {
-		args.add( tprintf( "-I%s", config->additional_includes[includeIndex].c_str() ) );
-	}
-
-	// must come before ignored warnings
-	if ( config->warnings_as_errors ) {
-		args.add( "-Werror" );
-	}
-
-	// warning levels
-	{
-		std::vector<std::string> allowedWarningLevels = {
-			"-Wall",
-			"-Wextra",
-			"-Wpedantic",
-		};
-
-		// gcc doesnt have this as a warning level but clang does
-		if ( isClang ) {
-			allowedWarningLevels.push_back( "-Weverything" );
-		}
-
-		For ( u64, warningLevelIndex, 0, config->warning_levels.size() ) {
-			const std::string& warningLevel = config->warning_levels[warningLevelIndex];
-
-			bool8 found = false;
-
-			For ( u64, allowedWarningLevelIndex, 0, allowedWarningLevels.size() ) {
-				if ( allowedWarningLevels[allowedWarningLevelIndex] == warningLevel ) {	// TODO(DM): 14/06/2025: better to compare hashes here instead?
-					found = true;
-					break;
-				}
-			}
-
-			if ( !found ) {
-				error( "\"%s\" is not allowed as a warning level.\n", warningLevel.c_str() );
-				return false;
-			}
-
-			args.add( warningLevel.c_str() );
-		}
-	}
-
-	For ( u64, ignoreWarningIndex, 0, config->ignore_warnings.size() ) {
-		args.add( config->ignore_warnings[ignoreWarningIndex].c_str() );
-	}
-
-	For ( u64, additionalArgumentIndex, 0, config->additional_compiler_arguments.size() ) {
-		args.add( config->additional_compiler_arguments[additionalArgumentIndex].c_str() );
-	}
-
-	s32 exitCode = RunProc( &args, NULL, PROC_FLAG_SHOW_ARGS | PROC_FLAG_SHOW_STDOUT );
+	// Source File
+	finalArgs.add( sourceFile );
+	
+	s32 exitCode = RunProc( &finalArgs, NULL, PROC_FLAG_SHOW_ARGS | PROC_FLAG_SHOW_STDOUT );
 
 	if ( exitCode == 0 ) {
 		ReadDependencyFile( depFilename, clangState->includeDependencies );
 	}
 
+	if ( recordCompilation ) {
+		RecordCompilationDatabaseEntry( buildContext, sourceFile, finalArgs );
+	}
+	
 	return exitCode == 0;
 }
 
@@ -459,6 +381,128 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t* backend, const Arra
 	s32 exitCode = RunProc( &args, NULL, PROC_FLAG_SHOW_ARGS | PROC_FLAG_SHOW_STDOUT );
 
 	return exitCode == 0;
+}
+
+static bool8 Clang_GetCompilationCommandArchetype( const compilerBackend_t* backend, const BuildConfig* config, compilationCommandArchetype_t& outCmdArchetype ) {
+
+	clangState_t *clangState = cast( clangState_t *, backend->data );
+	
+	const char* compilerPath = clangState->compilerPath.data;
+	
+	bool8 isClang = string_ends_with( compilerPath, "clang" ) || string_ends_with( compilerPath, "clang++" );
+
+	// Not used originally but leaving here for clarity
+	//bool8 isGCC = string_ends_with( backend->compilerPath.data, "gcc" ) || string_ends_with( backend->compilerPath.data, "g++" ); not used
+
+	const u64 definesCount              = config->defines.size();
+	const u64 additionalIncludesCount   = config->additional_includes.size();
+	const u64 ignoredWarningsCount      = config->ignore_warnings.size();
+	const u64 additionalArgsCount       = config->additional_compiler_arguments.size();
+
+	// Only reserve up enough up to additionalArgsCount,
+	// as we keep dependency flags, and the output flag separate
+	Array<const char*>& baseArgs = outCmdArchetype.baseArgs;
+	baseArgs.reserve(
+		1                       + // compiler path
+		1                       + // compile flag
+		1                       + // lang version flag
+		1                       + // symbols flag
+		1                       + // opt level flag
+		definesCount            +
+		additionalIncludesCount +
+		1                       + // warning as error flag
+		1                       + // warning level flag
+		ignoredWarningsCount    +
+		additionalArgsCount     +
+		2 );                      // dependency flags
+
+	// Compiler Path
+	baseArgs.add( compilerPath );
+
+	// Compile Flag
+	baseArgs.add( "-c" );
+
+	// Language Version
+	if ( config->language_version != LANGUAGE_VERSION_UNSET ) {
+		baseArgs.add( LanguageVersionToCompilerArg( config->language_version ) );
+	}
+
+	// Symbols Flag
+	if ( !config->remove_symbols ) {
+		baseArgs.add( "-g" );
+	}
+
+	// Optimization Level
+	baseArgs.add( OptimizationLevelToCompilerArg( config->optimization_level ) );
+
+	// Defines
+	For ( u32, defineIndex, 0, definesCount ) {
+		baseArgs.add( tprintf( "-D%s", config->defines[defineIndex].c_str() ) );
+	}
+
+	// Additional Includes
+	For ( u32, includeIndex, 0, additionalIncludesCount ) {
+		baseArgs.add( tprintf( "-I%s", config->additional_includes[includeIndex].c_str() ) );
+	}
+	
+	// Warning As Error
+	if ( config->warnings_as_errors ) {
+		baseArgs.add( "-Werror" );
+	}
+
+	// Warning Level
+	{
+		std::vector<std::string> allowedWarningLevels = {
+			"-Wall",
+			"-Wextra",
+			"-Wpedantic",
+		};
+
+		// gcc doesnt have this as a warning level but clang does
+		if ( isClang ) {
+			allowedWarningLevels.push_back( "-Weverything" );
+		}
+
+		//outArchetype.allowedWarningLevels.reserve( config->warning_levels.size() );
+		For ( u64, warningLevelIndex, 0, config->warning_levels.size() ) {
+			const std::string& warningLevel = config->warning_levels[warningLevelIndex];
+
+			bool8 found = false;
+
+			For ( u64, allowedWarningLevelIndex, 0, allowedWarningLevels.size() ) {
+				if ( allowedWarningLevels[allowedWarningLevelIndex] == warningLevel ) {	// TODO(DM): 14/06/2025: better to compare hashes here instead?
+					found = true;
+					break;
+				}
+			}
+
+			if ( !found ) {
+				error( "\"%s\" is not allowed as a warning level.\n", warningLevel.c_str() );
+				return false;
+			}
+
+			baseArgs.add( warningLevel.c_str() );
+		}
+	}
+
+	// Ignored Warnings
+	For ( u64, ignoreWarningIndex, 0, ignoredWarningsCount ) {
+		baseArgs.add( config->ignore_warnings[ignoreWarningIndex].c_str() );
+	}
+
+	// Additional Arguments
+	For ( u64, additionalArgumentIndex, 0, additionalArgsCount ) {
+		baseArgs.add( config->additional_compiler_arguments[additionalArgumentIndex].c_str() );
+	}
+
+	// Dependency Flags
+	outCmdArchetype.dependencyFlags.add( "-MMD" );
+	outCmdArchetype.dependencyFlags.add( "-MF" );
+
+	// Output Flag
+	outCmdArchetype.outputFlag = "-o";
+	
+	return true;
 }
 
 // only call this after compilation has finished successfully
@@ -591,6 +635,7 @@ void CreateCompilerBackend_Clang( compilerBackend_t* outBackend ) {
 		.Shutdown									= Clang_Shutdown,
 		.CompileSourceFile							= Clang_CompileSourceFile,
 		.LinkIntermediateFiles						= Clang_LinkIntermediateFiles,
+		.GetCompilationCommandArchetype				= Clang_GetCompilationCommandArchetype,
 		.GetIncludeDependenciesFromSourceFileBuild	= Clang_GetIncludeDependenciesFromSourceFileBuild,
 		.GetCompilerPath							= Clang_GetCompilerPath,
 		.GetCompilerVersion							= Clang_GetCompilerVersion,
@@ -604,6 +649,7 @@ void CreateCompilerBackend_GCC( compilerBackend_t* outBackend ) {
 		.Shutdown									= Clang_Shutdown,
 		.CompileSourceFile							= Clang_CompileSourceFile,
 		.LinkIntermediateFiles						= Clang_LinkIntermediateFiles,
+		.GetCompilationCommandArchetype				= Clang_GetCompilationCommandArchetype,
 		.GetIncludeDependenciesFromSourceFileBuild	= Clang_GetIncludeDependenciesFromSourceFileBuild,
 		.GetCompilerPath							= Clang_GetCompilerPath,
 		.GetCompilerVersion							= GCC_GetCompilerVersion,

--- a/src/backend_msvc.cpp
+++ b/src/backend_msvc.cpp
@@ -406,144 +406,37 @@ static void MSVC_Shutdown( compilerBackend_t* backend ) {
 	backend->data = NULL;
 }
 
-static bool8 MSVC_CompileSourceFile( compilerBackend_t* backend, const char* sourceFile, BuildConfig* config ) {
+static bool8 MSVC_CompileSourceFile(
+	compilerBackend_t* backend,
+	buildContext_t* buildContext,
+	BuildConfig* config,
+	compilationCommandArchetype_t& cmdArchetype,
+	const char* sourceFile,
+	bool recordCompilation )
+{
 	assert( backend );
 	assert( sourceFile );
 	assert( config );
 
 	const char* sourceFileNoPath = path_remove_path_from_file( sourceFile );
-
+	const char* sourceFileNoExtension = path_remove_file_extension( sourceFileNoPath );
 	const char* intermediatePath = tprintf( "%s%c%s", config->binary_folder.c_str(), PATH_SEPARATOR, INTERMEDIATE_PATH );
-	const char* intermediateFilename = tprintf( "%s%c%s.o", intermediatePath, PATH_SEPARATOR, sourceFileNoPath );
 
-	config->additional_includes.push_back( "." );
+	config->additional_includes.emplace_back( "." );
 
 	msvcState_t* msvcState = cast( msvcState_t*, backend->data );
 
 	msvcState->includeDependencies.clear();
 
-	Array<const char*>& args = msvcState->args;
-	args.reserve(
-		1 +	// cl
-		1 +	// /c
-		1 +	// /std=
-		1 +	// /DEBUG
-		1 +	// /O*
-		1 +	// /Fo:<intermediate filename>
-		1 + // /showIncludes
-		3 +	// -MD -MF <filename>
-		1 +	// source file
-		config->defines.size() +
-		config->additional_includes.size() +	// /I <include>
-		config->additional_lib_paths.size() +
-		config->additional_libs.size() +
-		1 +	// /WX
-		config->warning_levels.size() +
-		config->ignore_warnings.size()
-	);
+	Array<const char*> finalArgs = cmdArchetype.baseArgs;
 
-	args.reset();
+	// Fill up remaining arguments
+	
+	// Output Flag/File
+	finalArgs.add( tprintf("%s%s%c%s.o", cmdArchetype.outputFlag, intermediatePath, PATH_SEPARATOR, sourceFileNoExtension ) );
 
-	args.add( msvcState->compilerPath.data );
-
-	args.add( "/c" );
-
-	if ( config->language_version != LANGUAGE_VERSION_UNSET ) {
-		args.add( LanguageVersionToCompilerArg( config->language_version ) );
-	}
-
-	if ( !config->remove_symbols ) {
-		args.add( "/DEBUG" );
-	}
-
-	args.add( OptimizationLevelToCompilerArg( config->optimization_level ) );
-
-	args.add( tprintf( "/Fo%s", intermediateFilename ) );
-
-	args.add( "/showIncludes" );
-
-	args.add( sourceFile );
-
-	For ( u32, defineIndex, 0, config->defines.size() ) {
-		args.add( tprintf( "/D%s", config->defines[defineIndex].c_str() ) );
-	}
-
-	For ( u32, includeIndex, 0, msvcState->microsoftCoreIncludes.size() ) {
-		args.add( tprintf( "/I%s", msvcState->microsoftCoreIncludes[includeIndex].c_str() ) );
-	}
-
-	For ( u32, includeIndex, 0, config->additional_includes.size() ) {
-		args.add( tprintf( "/I%s", config->additional_includes[includeIndex].c_str() ) );
-	}
-
-	// must come before ignored warnings
-	if ( config->warnings_as_errors ) {
-		args.add( "/WX" );
-	}
-
-	// warning levels
-	{
-		std::vector<std::string> allowedWarningLevels = {
-			"/W",
-			"/W0",
-			"/W1",
-			"/W2",
-			"/W3",
-			"/W4",
-			"/Wall",
-		};
-
-		// MSVC only allows one warning level to be set
-		if ( config->warning_levels.size() > 1 ) {
-			StringBuilder builder;
-			string_builder_reset( &builder );
-
-			string_builder_appendf( &builder, "MSVC only allows ONE of the following warning levels to be set:\n" );
-
-			For ( u64, allowedWarningLevelIndex, 0, allowedWarningLevels.size() ) {
-				string_builder_appendf( &builder, "%s, ", allowedWarningLevels[allowedWarningLevelIndex].c_str() );
-			}
-
-			error( "%s\n", string_builder_to_string( &builder ) );
-
-			return false;
-		}
-
-		For ( u64, warningLevelIndex, 0, config->warning_levels.size() ) {
-			const std::string& warningLevel = config->warning_levels[warningLevelIndex];
-
-			bool8 found = false;
-
-			For ( u64, allowedWarningLevelIndex, 0, allowedWarningLevels.size() ) {
-				if ( allowedWarningLevels[allowedWarningLevelIndex] == warningLevel ) {	// TODO(DM): 14/06/2025: better to compare hashes here instead?
-					found = true;
-					break;
-				}
-			}
-
-			if ( !found ) {
-				error( "\"%s\" is not allowed as a warning level.\n", warningLevel.c_str() );
-				return false;
-			}
-
-			args.add( warningLevel.c_str() );
-		}
-	}
-
-	For ( u64, ignoreWarningIndex, 0, config->ignore_warnings.size() ) {
-		args.add( config->ignore_warnings[ignoreWarningIndex].c_str() );
-	}
-
-	For ( u64, additionalArgumentIndex, 0, config->additional_compiler_arguments.size() ) {
-		args.add( config->additional_compiler_arguments[additionalArgumentIndex].c_str() );
-	}
-
-	{
-		For ( u64, argIndex, 0, args.count ) {
-			printf( "%s ", msvcState->args[argIndex] );
-		}
-		printf( "\n" );
-	}
+	// Source File
+	finalArgs.add( sourceFile );
 
 	// MSVC doesnt output include dependencies to .d files
 	// it only supports printing them to stdout
@@ -553,7 +446,7 @@ static bool8 MSVC_CompileSourceFile( compilerBackend_t* backend, const char* sou
 	string_builder_reset( &processStdout );
 	defer( string_builder_destroy( &processStdout ) );
 	{
-		Process* process = process_create( &args, NULL, PROCESS_FLAG_ASYNC | PROCESS_FLAG_COMBINE_STDOUT_AND_STDERR );
+		Process* process = process_create( &finalArgs, NULL, PROCESS_FLAG_ASYNC | PROCESS_FLAG_COMBINE_STDOUT_AND_STDERR );
 
 		char buffer[1024] = { 0 };
 		u64 bytesRead = U64_MAX;
@@ -613,6 +506,10 @@ static bool8 MSVC_CompileSourceFile( compilerBackend_t* backend, const char* sou
 			lineStart = lineEnd + 1;
 		}
 	}
+	
+	if ( recordCompilation ) {
+		RecordCompilationDatabaseEntry( buildContext, sourceFile, finalArgs );
+	}
 
 	return exitCode == 0;
 }
@@ -670,6 +567,143 @@ static bool8 MSVC_LinkIntermediateFiles( compilerBackend_t* backend, const Array
 	return exitCode == 0;
 }
 
+static bool8 MSVC_GetCompilationCommandArchetype( const compilerBackend_t* backend, const BuildConfig* config, compilationCommandArchetype_t& outCmdArchetype ) {
+
+	msvcState_t* msvcState = cast( msvcState_t*, backend->data );
+	
+	const u64 definesCount               = config->defines.size();
+	const u64 microsoftCoreIncludesCount = msvcState->microsoftCoreIncludes.size();
+	const u64 additionalIncludesCount    = config->additional_includes.size();
+	const u64 ignoredWarningsCount       = config->ignore_warnings.size();
+	const u64 additionalArgsCount        = config->additional_compiler_arguments.size();
+
+	Array<const char*>& baseArgs = outCmdArchetype.baseArgs;
+	baseArgs.reserve(
+		1                          + // compilerPath
+		1                          + // compile flag
+		1                          + // lang version flag
+		1                          + // symbols flag
+		1                          + // opt level flag
+		definesCount               +
+		microsoftCoreIncludesCount +
+		additionalIncludesCount	   +
+		1                          + // warning as error flag
+		1                          + // warning level flag
+		ignoredWarningsCount       +
+		additionalArgsCount
+	);
+
+	// Compiler Path
+	baseArgs.add( msvcState->compilerPath.data );
+
+	// Compile Flag
+	baseArgs.add( "/c" );
+
+	// Language Version
+	if ( config->language_version != LANGUAGE_VERSION_UNSET ) {
+		baseArgs.add( LanguageVersionToCompilerArg( config->language_version ) );
+	}
+
+	// Symbols Flag
+	if ( !config->remove_symbols ) {
+		baseArgs.add( "/DEBUG" );
+	}
+
+	// Optimization Level
+	baseArgs.add( OptimizationLevelToCompilerArg( config->optimization_level ) );
+
+	// Diagnostics Flag
+	baseArgs.add( "/showIncludes" );
+
+	// Defines
+	For ( u32, defineIndex, 0, definesCount ) {
+		baseArgs.add( tprintf( "/D%s", config->defines[defineIndex].c_str() ) );
+	}
+	
+	// Microsoft Core Includes
+	For ( u32, includeIndex, 0, microsoftCoreIncludesCount ) {
+		baseArgs.add( tprintf( "/I%s", msvcState->microsoftCoreIncludes[includeIndex].c_str() ) );
+	}
+
+	// Additional Includes
+	For ( u32, includeIndex, 0, additionalIncludesCount ) {
+		baseArgs.add( tprintf( "/I%s", config->additional_includes[includeIndex].c_str() ) );
+	}
+
+	// Warning As Error
+	if ( config->warnings_as_errors ) {
+		baseArgs.add( "/WX" );
+	}
+
+	// Warning Level
+	{
+		std::vector<std::string> allowedWarningLevels = {
+			"/W",
+			"/W0",
+			"/W1",
+			"/W2",
+			"/W3",
+			"/W4",
+			"/Wall",
+		};
+
+		// MSVC only allows one warning level to be set
+		if ( config->warning_levels.size() > 1 ) {
+			StringBuilder builder;
+			string_builder_reset( &builder );
+
+			string_builder_appendf( &builder, "MSVC only allows ONE of the following warning levels to be set:\n" );
+
+			For ( u64, allowedWarningLevelIndex, 0, allowedWarningLevels.size() ) {
+				string_builder_appendf( &builder, "%s, ", allowedWarningLevels[allowedWarningLevelIndex].c_str() );
+			}
+
+			error( "%s\n", string_builder_to_string( &builder ) );
+
+			return false;
+		}
+
+		For ( u64, warningLevelIndex, 0, config->warning_levels.size() )
+		{
+			const std::string& warningLevel = config->warning_levels[warningLevelIndex];
+
+			bool8 found = false;
+
+			For ( u64, allowedWarningLevelIndex, 0, allowedWarningLevels.size() ) {
+				if ( allowedWarningLevels[allowedWarningLevelIndex] == warningLevel ) {	// TODO(DM): 14/06/2025: better to compare hashes here instead?
+					found = true;
+					break;
+				}
+			}
+
+			if ( !found ) {
+				error( "\"%s\" is not allowed as a warning level.\n", warningLevel.c_str() );
+				return false;
+			}
+
+			baseArgs.add( warningLevel.c_str() );
+		}
+	}
+
+	// Ignored Warnings
+	For ( u64, ignoreWarningIndex, 0, ignoredWarningsCount ) {
+		baseArgs.add( config->ignore_warnings[ignoreWarningIndex].c_str() );
+	}
+
+	// Additional Arguments
+	For ( u64, additionalArgumentIndex, 0, additionalArgsCount ) {
+		baseArgs.add( config->additional_compiler_arguments[additionalArgumentIndex].c_str() );
+	}
+
+	// Dependency Flags
+	// MSVC doesn't have any
+	
+	// Output Flag
+	outCmdArchetype.outputFlag = "/Fo";
+
+	return true;
+}
+
 static void MSVC_GetIncludeDependenciesFromSourceFileBuild( compilerBackend_t* backend, std::vector<std::string>& outIncludeDependencies ) {
 	msvcState_t* msvcState = cast( msvcState_t*, backend->data );
 
@@ -695,6 +729,7 @@ void CreateCompilerBackend_MSVC( compilerBackend_t* outBackend ) {
 		.Shutdown									= MSVC_Shutdown,
 		.CompileSourceFile							= MSVC_CompileSourceFile,
 		.LinkIntermediateFiles						= MSVC_LinkIntermediateFiles,
+		.GetCompilationCommandArchetype		        = MSVC_GetCompilationCommandArchetype,
 		.GetIncludeDependenciesFromSourceFileBuild	= MSVC_GetIncludeDependenciesFromSourceFileBuild,
 		.GetCompilerPath							= MSVC_GetCompilerPath,
 		.GetCompilerVersion							= MSVC_GetCompilerVersion,

--- a/tests/test_compilation_database/build_configs.cpp
+++ b/tests/test_compilation_database/build_configs.cpp
@@ -1,0 +1,28 @@
+﻿// Test source file for compilation database with multiple source files.
+// This validates that ALL compiled source files appear in the compilation database.
+
+#if BUILDER_DOING_USER_CONFIG_BUILD
+
+#include <builder.h>
+
+static void get_build_configs( BuilderOptions* options ) {
+
+    options->generate_compilation_database = true;
+    
+    BuildConfig config = {
+        .binary_name = "test_compilation_database_program",
+        .binary_folder = "bin",
+        .language_version = LANGUAGE_VERSION_CPP17,
+        .optimization_level = OPTIMIZATION_LEVEL_O0,
+        .remove_symbols = false,
+        .defines = { "TEST_DEFINE" },
+        .source_files = {
+            "src/main.cpp",
+            "src/helper.cpp",
+        }
+    };
+
+    add_build_config( options, &config );
+}
+
+#endif // BUILDER_DOING_USER_CONFIG_BUILD

--- a/tests/test_compilation_database/src/helper.cpp
+++ b/tests/test_compilation_database/src/helper.cpp
@@ -1,0 +1,12 @@
+﻿#include <stdio.h>
+
+extern int helper_function();
+
+int main( int argc, char** argv ) {
+    ( (void) argc );
+    ( (void) argv );
+
+    printf( "Result: %d\n", helper_function() );
+
+    return 0;
+}

--- a/tests/test_compilation_database/src/main.cpp
+++ b/tests/test_compilation_database/src/main.cpp
@@ -1,0 +1,4 @@
+﻿
+int helper_function() {
+    return 42;
+}

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -92,7 +92,9 @@
   <ItemGroup>
     <ClCompile Include="tests_main.cpp" />
     <ClCompile Include="test_basic\test_basic.cpp" />
-    <ClCompile Include="test_compiler_path\test_compiler_path.cpp" />
+    <ClCompile Include="test_compilation_database\build_configs.cpp" />
+    <ClCompile Include="test_compilation_database\src\helper.cpp" />
+    <ClCompile Include="test_compilation_database\src\main.cpp" />
     <ClCompile Include="test_dynamic_lib\build_configs.cpp" />
     <ClCompile Include="test_dynamic_lib\lib\lib.cpp" />
     <ClCompile Include="test_dynamic_lib\program\program.cpp" />
@@ -132,12 +134,11 @@
     <Content Include="test_static_lib\.builder\build.so" />
     <Content Include="test_static_lib\.builder\intermediate\build.cpp.d" />
     <Content Include="test_static_lib\.builder\intermediate\build.cpp.o" />
-    <Content Include="test_static_lib\bin\intermediate\lib.cpp.d" />
-    <Content Include="test_static_lib\bin\intermediate\lib.cpp.o" />
-    <Content Include="test_static_lib\bin\intermediate\program.cpp.d" />
-    <Content Include="test_static_lib\bin\intermediate\program.cpp.o" />
-    <Content Include="test_static_lib\bin\test_static_lib.a" />
-    <Content Include="test_static_lib\bin\test_static_library_program" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="test_compilation_database\.builder\" />
+    <Folder Include="test_compilation_database\bin\" />
+    <Folder Include="test_static_lib\bin\" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" Condition="'$(OS)' == 'Windows_NT'" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Implemented a functional pass of compilation databases generation for clang-based tooling. Code editors and IDE's, such as Clion, VSCode, Zed Editor (between others), support these "project specification format", allowing the user to start coding with minimal setup (among other festures).

For every successfully compiled source file, we record an compilation database entry. If, and only if, the build processs succeeds entirely, a compile_commands.json will be generated at same location of the build script of the given project.

This implementation follows the standard specified [here](https://clang.llvm.org/docs/JSONCompilationDatabase.html).




