### PR TITLE
fix issues with linking the windows standard library

### DIFF
--- a/src/backend_clang.cpp
+++ b/src/backend_clang.cpp
@@ -337,7 +337,7 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 		1 + // /DEBUG
 		1 + // /OUT:
 		1 + // kernel32.lib
-		3 + // CRT libs (msvcrt, vcruntime, ucrt)
+		4 + // CRT libs (e.g. msvcrt, msvcprt, vcruntime, ucrt when -D_DLL and NOT -D_DEBUG) 
 		3 + // /LIBPATH: ucrt, um, msvc
 		intermediateFiles.count +
 		config->additionalLibPaths.size() +
@@ -383,15 +383,66 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 
 	args.add( "kernel32.lib" );
 
-#if defined( _DEBUG )
-	args.add( "msvcrtd.lib" );
-	args.add( "vcruntimed.lib" );
-	args.add( "ucrtd.lib" );
-#else
-	args.add( "msvcrt.lib" );
-	args.add( "vcruntime.lib" );
-	args.add( "ucrt.lib" );
-#endif
+	bool8 isUserConfigBuild = false;
+	bool8 debugBuild = false;
+	bool8 hasDllRuntime = false;
+	For ( u32, i, 0, config->defines.size() ) {
+		if ( config->defines[i] == "BUILDER_DOING_USER_CONFIG_BUILD" ) {
+			isUserConfigBuild = true;
+		}
+		if ( config->defines[i] == "_DEBUG" ) {
+			 debugBuild = config->binaryType != BINARY_TYPE_STATIC_LIBRARY; 
+		}
+		if ( config->defines[i] == "_DLL" ) {
+			hasDllRuntime = true;
+		}
+	}
+
+	if ( !isUserConfigBuild ) {
+
+		if( debugBuild ) {
+			if ( hasDllRuntime ) {
+			args.add( "msvcrtd.lib" );
+			args.add( "msvcprtd.lib" );
+			args.add( "vcruntimed.lib" );
+			args.add( "ucrtd.lib" );
+			}
+			else {
+				args.add( "libcmtd.lib" );
+				args.add( "libcpmtd.lib" );
+				args.add( "libvcruntimed.lib" );
+				args.add( "libucrtd.lib" );
+			}
+		} else {
+			if ( hasDllRuntime ) {
+				args.add( "msvcrt.lib" );
+				args.add( "msvcprt.lib" );
+				args.add( "vcruntime.lib" );
+				args.add( "ucrt.lib" );
+			}
+			else {
+				args.add( "libcmt.lib" );
+				args.add( "libcpmt.lib" );
+				args.add( "libvcruntime.lib" );
+				args.add( "libucrt.lib" );
+			}
+		}
+	}
+	else
+	{
+		// libraries for user config
+		#if defined( _DEBUG )
+			args.add( "msvcrtd.lib" );
+			args.add( "msvcprtd.lib" );
+			args.add( "vcruntimed.lib" );
+			args.add( "ucrtd.lib" );
+		#else
+			args.add( "msvcrt.lib" );
+			args.add( "msvcprt.lib" );
+			args.add( "vcruntime.lib" );
+			args.add( "ucrt.lib" );
+		#endif
+	}
 
 	For ( u32, libIndex, 0, config->additionalLibs.size() ) {
 		args.add( tprintf( "%s%s", config->additionalLibs[libIndex].c_str(), GetFileExtensionFromBinaryType( BINARY_TYPE_STATIC_LIBRARY ) ) );


### PR DESCRIPTION
This will definitely need some polish but I have covered the weird lib detection that the C++ std library does. The way to check for the user build config isn't the nicest but lined up well with the other define checks. 

Some of this feels like it should be better exposed but I just can't think how. Also begs the question of why provide `/NODEFAULTLIB`? I am assuming this was to fix another issue though.

There is some contention with how all of this should be used with clang, as it has the flag `ms-runtime-lib` which can be used like:
`-fms-runtime-lib=dll_dbg`
Which I believe would set for you both the `_DLL` and `_DEBUG` defines.

This is mostly assumed as compiling with both `#define _DEBUG` and `#define _DLL` with any combination of that flag set to:
- dll_dbg
- static_dbg
- static
- dll
Has no effect on the linking process.

Assuming we account for user stupidity the most robust check to know we are linking to the right libs would be:
1. Check for debug via define of `_DEBUG` (no conflicting `NDEBUG` will override this for lib check)
2. Check for debug via either of `dll_dbg` or `static_dbg` being set by the ms-runtime-lib flag
3. Check for dynamic linkage via define of `_DLL`
4. Check for dynamic linkage via either of `dll_dbg` or `dll` being set by the ms-runtime-lib flag
Then it's now simple to check against isDebug and isDynamicLinkage to accurately link against the windows libraries..... Fun.

