### PR TITLE
Dev windows stdlib linking

### DIFF
--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -66,18 +66,18 @@ set includes=-Isrc\\core\\include -Iclang\\include
 
 set libPaths=-Lclang\\lib
 
-set libraries=-luser32.lib -lShlwapi.lib -lDbgHelp.lib -lOle32.lib -lAdvapi32.lib -lOleAut32.lib -llibclang.lib
+set libraries=-luser32.lib -lShlwapi.lib -lDbgHelp.lib -lOle32.lib -lAdvapi32.lib -lOleAut32.lib -llibclang.lib -lkernel32.lib
 if /I [%config%] == [debug] (
-	set libraries=!libraries! -lmsvcrtd.lib
+	set libraries=!libraries! -lmsvcrtd.lib -lmsvcprtd.lib -lvcruntimed.lib -lucrtd.lib
 ) else (
-	set libraries=!libraries! -lmsvcrt.lib
+	set libraries=!libraries! -lmsvcrt.lib -lmsvcprt.lib -lvcruntime.lib -lucrt.lib
 )
 
 set warningLevels=-Werror -Wall -Wextra -Weverything -Wpedantic
 
 set ignoreWarnings=-Wno-newline-eof -Wno-format-nonliteral -Wno-gnu-zero-variadic-macro-arguments -Wno-declaration-after-statement -Wno-unsafe-buffer-usage -Wno-zero-as-null-pointer-constant -Wno-c++98-compat-pedantic -Wno-old-style-cast -Wno-missing-field-initializers -Wno-switch-default -Wno-covered-switch-default -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-cast-align -Wno-double-promotion -Wno-nontrivial-memcall -Wno-documentation-unknown-command -Wno-switch
 
-set args=clang\\bin\\clang -std=c++20 -o %binFolder%\\%programName%.exe %symbols% %optimisation% %sourceFiles% !defines! %includes% %libPaths% !libraries! %warningLevels% %ignoreWarnings%
+set args=clang\\bin\\clang -Xlinker /NODEFAULTLIB -std=c++20 -o %binFolder%\\%programName%.exe %symbols% %optimisation% %sourceFiles% !defines! %includes% %libPaths% !libraries! %warningLevels% %ignoreWarnings%
 echo %args%
 %args%
 

--- a/src/backend_clang.cpp
+++ b/src/backend_clang.cpp
@@ -383,13 +383,10 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 
 	args.add( "kernel32.lib" );
 
-	bool8 isUserConfigBuild = false;
+	// these defines are what drive the choice of lib windows std compiles against
 	bool8 debugBuild = false;
 	bool8 hasDllRuntime = false;
 	For ( u32, i, 0, config->defines.size() ) {
-		if ( config->defines[i] == "BUILDER_DOING_USER_CONFIG_BUILD" ) {
-			isUserConfigBuild = true;
-		}
 		if ( config->defines[i] == "_DEBUG" ) {
 			 debugBuild = true; 
 		}
@@ -398,7 +395,8 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 		}
 	}
 
-	if ( !isUserConfigBuild && config->binaryType != BINARY_TYPE_STATIC_LIBRARY ) {
+	// static library doesn't pass /NODEFAULTLIB so we don't need to supply it ourselves
+	if ( config->binaryType != BINARY_TYPE_STATIC_LIBRARY ) {
 		if( debugBuild ) {
 			if ( hasDllRuntime ) {
 			args.add( "msvcrtd.lib" );
@@ -426,21 +424,6 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 				args.add( "libucrt.lib" );
 			}
 		}
-	}
-	else if ( config->binaryType != BINARY_TYPE_STATIC_LIBRARY )
-	{
-		// libraries for user config
-		#if defined( _DEBUG )
-			args.add( "msvcrtd.lib" );
-			args.add( "msvcprtd.lib" );
-			args.add( "vcruntimed.lib" );
-			args.add( "ucrtd.lib" );
-		#else
-			args.add( "msvcrt.lib" );
-			args.add( "msvcprt.lib" );
-			args.add( "vcruntime.lib" );
-			args.add( "ucrt.lib" );
-		#endif
 	}
 
 	For ( u32, libIndex, 0, config->additionalLibs.size() ) {

--- a/src/backend_clang.cpp
+++ b/src/backend_clang.cpp
@@ -337,7 +337,7 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 		1 + // /DEBUG
 		1 + // /OUT:
 		1 + // kernel32.lib
-		3 + // CRT libs (msvcrt, vcruntime, ucrt)
+		4 + // CRT libs (e.g. msvcrt, msvcprt, vcruntime, ucrt when -D_DLL and NOT -D_DEBUG) 
 		3 + // /LIBPATH: ucrt, um, msvc
 		intermediateFiles.count +
 		config->additionalLibPaths.size() +
@@ -383,15 +383,65 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 
 	args.add( "kernel32.lib" );
 
-#if defined( _DEBUG )
-	args.add( "msvcrtd.lib" );
-	args.add( "vcruntimed.lib" );
-	args.add( "ucrtd.lib" );
-#else
-	args.add( "msvcrt.lib" );
-	args.add( "vcruntime.lib" );
-	args.add( "ucrt.lib" );
-#endif
+	bool8 isUserConfigBuild = false;
+	bool8 debugBuild = false;
+	bool8 hasDllRuntime = false;
+	For ( u32, i, 0, config->defines.size() ) {
+		if ( config->defines[i] == "BUILDER_DOING_USER_CONFIG_BUILD" ) {
+			isUserConfigBuild = true;
+		}
+		if ( config->defines[i] == "_DEBUG" ) {
+			 debugBuild = true; 
+		}
+		if ( config->defines[i] == "_DLL" ) {
+			hasDllRuntime = true;
+		}
+	}
+
+	if ( !isUserConfigBuild && config->binaryType != BINARY_TYPE_STATIC_LIBRARY ) {
+		if( debugBuild ) {
+			if ( hasDllRuntime ) {
+			args.add( "msvcrtd.lib" );
+			args.add( "msvcprtd.lib" );
+			args.add( "vcruntimed.lib" );
+			args.add( "ucrtd.lib" );
+			}
+			else {
+				args.add( "libcmtd.lib" );
+				args.add( "libcpmtd.lib" );
+				args.add( "libvcruntimed.lib" );
+				args.add( "libucrtd.lib" );
+			}
+		} else {
+			if ( hasDllRuntime ) {
+				args.add( "msvcrt.lib" );
+				args.add( "msvcprt.lib" );
+				args.add( "vcruntime.lib" );
+				args.add( "ucrt.lib" );
+			}
+			else {
+				args.add( "libcmt.lib" );
+				args.add( "libcpmt.lib" );
+				args.add( "libvcruntime.lib" );
+				args.add( "libucrt.lib" );
+			}
+		}
+	}
+	else if ( config->binaryType != BINARY_TYPE_STATIC_LIBRARY )
+	{
+		// libraries for user config
+		#if defined( _DEBUG )
+			args.add( "msvcrtd.lib" );
+			args.add( "msvcprtd.lib" );
+			args.add( "vcruntimed.lib" );
+			args.add( "ucrtd.lib" );
+		#else
+			args.add( "msvcrt.lib" );
+			args.add( "msvcprt.lib" );
+			args.add( "vcruntime.lib" );
+			args.add( "ucrt.lib" );
+		#endif
+	}
 
 	For ( u32, libIndex, 0, config->additionalLibs.size() ) {
 		args.add( tprintf( "%s%s", config->additionalLibs[libIndex].c_str(), GetFileExtensionFromBinaryType( BINARY_TYPE_STATIC_LIBRARY ) ) );

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -1237,6 +1237,7 @@ int BuilderMain( const int firstArg, int argc, const char * const * argv ) {
 #else
 				"NDEBUG",
 #endif
+				"_DLL"
 			},
 			.additionalIncludes = {
 				// add the folder that builder lives in as an additional include path otherwise people have no real way of being able to include it


### PR DESCRIPTION
This will definitely need some polish but I have covered the weird lib detection that the C++ std library does. The way to check for the user build config isn't the nicest but lined up well with the other define checks.

Some of this feels like it should be better exposed but I just can't think how. Also begs the question of why provide /NODEFAULTLIB? I am assuming this was to fix another issue though.

There is some contention with how all of this should be used with clang, as it has the flag ms-runtime-lib which can be used like:
-fms-runtime-lib=dll_dbg
Which I believe would set for you both the _DLL and _DEBUG defines.

This is mostly assumed as compiling with both #define _DEBUG and #define _DLL with any combination of that flag set to:

-    dll_dbg
-    static_dbg
-    static
-    dll

Has no effect on the linking process. 

Assuming we account for user stupidity the most robust check to know we are linking to the right libs would be:
1. Check for debug via define of _DEBUG (no conflicting NDEBUG will override this for lib check)
2. Check for debug via either of dll_dbg or static_dbg being set by the ms-runtime-lib flag
3. Check for dynamic linkage via define of _DLL
4. Check for dynamic linkage via either of dll_dbg or dll being set by the ms-runtime-lib flag

Then it's now simple to check against isDebug and isDynamicLinkage to accurately link against the windows libraries..... Fun.
