### PR TITLE
Windows stdlib linking

### DIFF
--- a/include/builder.h
+++ b/include/builder.h
@@ -282,6 +282,12 @@ struct BuilderOptions {
 	// This is because on Windows the C and C++ runtimes come in both static and dynamic versions, and you have to choose which one you want to compile with and link against.
 	// All this does is set the _DLL preprocessor definition for you, which changes linking behavior to use the dynamic runtime.
 	bool						linkAgainstWindowsDynamicRuntime;
+
+	// Tell Builder to ignore the default libraries that the compiler would normally link against.
+	// Specifically, if you don't want to link against the standard library, this is useful.
+	// Does not do anything for static library builds
+	// Note: This also does not guarantee linking of kernel32 or libgcc
+	bool 						noDefaultLibs;
 };
 
 struct CommandLineArgs {

--- a/include/builder.h
+++ b/include/builder.h
@@ -277,6 +277,11 @@ struct BuilderOptions {
 	// Do you want to generate a compilation_commands.json for Clang tooling?
 	// If true, the file will be generated IF the build is successful.
 	bool						generateCompilationDatabase;
+
+	// For windows target platform: Do you want to link against the Windows dynamic runtime (DLL) instead of the static runtime (LIB)?
+	// This is because on Windows the C and C++ runtimes come in both static and dynamic versions, and you have to choose which one you want to compile with and link against.
+	// All this does is set the _DLL preprocessor definition for you, which changes linking behavior to use the dynamic runtime.
+	bool						linkAgainstWindowsDynamicRuntime;
 };
 
 struct CommandLineArgs {

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -68,9 +68,9 @@ set libPaths=-Lclang\\lib
 
 set libraries=-luser32.lib -lShlwapi.lib -lDbgHelp.lib -lOle32.lib -lAdvapi32.lib -lOleAut32.lib -llibclang.lib -lkernel32.lib
 if /I [%config%] == [debug] (
-	set libraries=!libraries! -lmsvcrtd.lib -lmsvcprtd.lib -lvcruntimed.lib -lucrtd.lib
+	set libraries=!libraries! -llibcmtd.lib -llibcpmtd.lib -llibvcruntimed.lib -llibucrtd.lib
 ) else (
-	set libraries=!libraries! -lmsvcrt.lib -lmsvcprt.lib -lvcruntime.lib -lucrt.lib
+	set libraries=!libraries! -llibcmt.lib -llibcpmt.lib -llibvcruntime.lib -llibucrt.lib
 )
 
 set warningLevels=-Werror -Wall -Wextra -Weverything -Wpedantic

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -66,18 +66,18 @@ set includes=-Isrc\\core\\include -Iclang\\include
 
 set libPaths=-Lclang\\lib
 
-set libraries=-luser32.lib -lShlwapi.lib -lDbgHelp.lib -lOle32.lib -lAdvapi32.lib -lOleAut32.lib -llibclang.lib
+set libraries=-luser32.lib -lShlwapi.lib -lDbgHelp.lib -lOle32.lib -lAdvapi32.lib -lOleAut32.lib -llibclang.lib -lkernel32.lib
 if /I [%config%] == [debug] (
-	set libraries=!libraries! -lmsvcrtd.lib
+	set libraries=!libraries! -lmsvcrtd.lib -lmsvcprtd.lib -lvcruntimed.lib -lucrtd.lib
 ) else (
-	set libraries=!libraries! -lmsvcrt.lib
+	set libraries=!libraries! -lmsvcrt.lib -lmsvcprt.lib -lvcruntime.lib -lucrt.lib
 )
 
 set warningLevels=-Werror -Wall -Wextra -Weverything -Wpedantic
 
 set ignoreWarnings=-Wno-newline-eof -Wno-format-nonliteral -Wno-gnu-zero-variadic-macro-arguments -Wno-declaration-after-statement -Wno-unsafe-buffer-usage -Wno-zero-as-null-pointer-constant -Wno-c++98-compat-pedantic -Wno-old-style-cast -Wno-missing-field-initializers -Wno-switch-default -Wno-covered-switch-default -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-cast-align -Wno-double-promotion -Wno-nontrivial-memcall -Wno-documentation-unknown-command -Wno-switch
 
-set args=clang\\bin\\clang -std=c++20 -o %binFolder%\\%programName%.exe %symbols% %optimisation% %sourceFiles% !defines! %includes% %libPaths% !libraries! %warningLevels% %ignoreWarnings%
+set args=clang\\bin\\clang -Xlinker /NODEFAULTLIB -std=c++20 -o %binFolder%\\%programName%.exe %symbols% %optimisation% %sourceFiles% !defines! %includes% %libPaths% !libraries! %warningLevels% %ignoreWarnings%
 echo %args%
 %args%
 

--- a/src/backend_clang.cpp
+++ b/src/backend_clang.cpp
@@ -320,7 +320,7 @@ static bool8 Clang_CompileSourceFile(
 	return exitCode == 0;
 }
 
-static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Array<const char *> &intermediateFiles, BuildConfig *config ) {
+static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Array<const char *> &intermediateFiles, BuildConfig *config, const BuilderOptions *options ) {
 	assert( backend );
 	assert( config );
 
@@ -381,47 +381,49 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 		args.add( tprintf( "/LIBPATH:%s", config->additionalLibPaths[libPathIndex].c_str() ) );
 	}
 
-	args.add( "kernel32.lib" );
+	if ( !options || !options->noDefaultLibs ) {
+		args.add( "kernel32.lib" );
 
-	// these defines are what drive the choice of lib windows std compiles against
-	bool8 debugBuild = false;
-	bool8 hasDllRuntime = false;
-	For ( u32, i, 0, config->defines.size() ) {
-		if ( config->defines[i] == "_DEBUG" ) {
-			 debugBuild = true; 
+		// these defines are what drive the choice of lib windows std compiles against
+		bool8 debugBuild = false;
+		bool8 hasDllRuntime = false;
+		For ( u32, i, 0, config->defines.size() ) {
+			if ( config->defines[i] == "_DEBUG" ) {
+				debugBuild = true; 
+			}
+			if ( config->defines[i] == "_DLL" ) {
+				hasDllRuntime = true;
+			}
 		}
-		if ( config->defines[i] == "_DLL" ) {
-			hasDllRuntime = true;
-		}
-	}
 
-	// static library doesn't pass /NODEFAULTLIB so we don't need to supply it ourselves
-	if ( config->binaryType != BINARY_TYPE_STATIC_LIBRARY ) {
-		if( debugBuild ) {
-			if ( hasDllRuntime ) {
-			args.add( "msvcrtd.lib" );
-			args.add( "msvcprtd.lib" );
-			args.add( "vcruntimed.lib" );
-			args.add( "ucrtd.lib" );
-			}
-			else {
-				args.add( "libcmtd.lib" );
-				args.add( "libcpmtd.lib" );
-				args.add( "libvcruntimed.lib" );
-				args.add( "libucrtd.lib" );
-			}
-		} else {
-			if ( hasDllRuntime ) {
-				args.add( "msvcrt.lib" );
-				args.add( "msvcprt.lib" );
-				args.add( "vcruntime.lib" );
-				args.add( "ucrt.lib" );
-			}
-			else {
-				args.add( "libcmt.lib" );
-				args.add( "libcpmt.lib" );
-				args.add( "libvcruntime.lib" );
-				args.add( "libucrt.lib" );
+		// static library doesn't pass /NODEFAULTLIB so we don't need to supply it ourselves
+		if ( config->binaryType != BINARY_TYPE_STATIC_LIBRARY ) {
+			if( debugBuild ) {
+				if ( hasDllRuntime ) {
+				args.add( "msvcrtd.lib" );
+				args.add( "msvcprtd.lib" );
+				args.add( "vcruntimed.lib" );
+				args.add( "ucrtd.lib" );
+				}
+				else {
+					args.add( "libcmtd.lib" );
+					args.add( "libcpmtd.lib" );
+					args.add( "libvcruntimed.lib" );
+					args.add( "libucrtd.lib" );
+				}
+			} else {
+				if ( hasDllRuntime ) {
+					args.add( "msvcrt.lib" );
+					args.add( "msvcprt.lib" );
+					args.add( "vcruntime.lib" );
+					args.add( "ucrt.lib" );
+				}
+				else {
+					args.add( "libcmt.lib" );
+					args.add( "libcpmt.lib" );
+					args.add( "libvcruntime.lib" );
+					args.add( "libucrt.lib" );
+				}
 			}
 		}
 	}
@@ -507,7 +509,7 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 	return exitCode == 0;
 }
 
-static bool8 GCC_LinkIntermediateFiles( compilerBackend_t *backend, const Array<const char *> &intermediateFiles, BuildConfig *config ) {
+static bool8 GCC_LinkIntermediateFiles( compilerBackend_t *backend, const Array<const char *> &intermediateFiles, BuildConfig *config, const BuilderOptions *options ) {
 	assert( backend );
 	assert( config );
 
@@ -520,6 +522,7 @@ static bool8 GCC_LinkIntermediateFiles( compilerBackend_t *backend, const Array<
 		1 + // lld-link
 		1 + // verbose flag
 		1 + // /lib or -shared
+		1 + // -nodefaultlibs
 		1 + // -g
 		1 + // -o
 		1 + // binary name
@@ -553,6 +556,10 @@ static bool8 GCC_LinkIntermediateFiles( compilerBackend_t *backend, const Array<
 
 		if ( !config->removeSymbols ) {
 			args.add( "-g" );
+		}
+
+		if ( options && options->noDefaultLibs ) {
+			args.add( "-nodefaultlibs" );
 		}
 
 		if ( g_verbose ) {

--- a/src/backend_clang.cpp
+++ b/src/backend_clang.cpp
@@ -383,13 +383,10 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 
 	args.add( "kernel32.lib" );
 
-	bool8 isUserConfigBuild = false;
+	// these defines are what drive the choice of lib windows std compiles against
 	bool8 debugBuild = false;
 	bool8 hasDllRuntime = false;
 	For ( u32, i, 0, config->defines.size() ) {
-		if ( config->defines[i] == "BUILDER_DOING_USER_CONFIG_BUILD" ) {
-			isUserConfigBuild = true;
-		}
 		if ( config->defines[i] == "_DEBUG" ) {
 			 debugBuild = true; 
 		}
@@ -398,7 +395,8 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 		}
 	}
 
-	if ( !isUserConfigBuild && config->binaryType != BINARY_TYPE_STATIC_LIBRARY ) {
+	// static library doesn't pass /NODEFAULTLIB so we don't need to supply it ourselves
+	if ( config->binaryType != BINARY_TYPE_STATIC_LIBRARY ) {
 		if( debugBuild ) {
 			if ( hasDllRuntime ) {
 			args.add( "msvcrtd.lib" );
@@ -426,21 +424,6 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 				args.add( "libucrt.lib" );
 			}
 		}
-	}
-	else if ( config->binaryType != BINARY_TYPE_STATIC_LIBRARY )
-	{
-		// libraries for user config
-		#if defined( _DEBUG )
-			args.add( "msvcrtd.lib" );
-			args.add( "msvcprtd.lib" );
-			args.add( "vcruntimed.lib" );
-			args.add( "ucrtd.lib" );
-		#else
-			args.add( "msvcrt.lib" );
-			args.add( "msvcprt.lib" );
-			args.add( "vcruntime.lib" );
-			args.add( "ucrt.lib" );
-		#endif
 	}
 
 	For ( u32, libIndex, 0, config->additionalLibs.size() ) {

--- a/src/backend_clang.cpp
+++ b/src/backend_clang.cpp
@@ -337,7 +337,7 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 		1 + // /DEBUG
 		1 + // /OUT:
 		1 + // kernel32.lib
-		3 + // CRT libs (msvcrt, vcruntime, ucrt)
+		4 + // CRT libs (e.g. msvcrt, msvcprt, vcruntime, ucrt when -D_DLL and NOT -D_DEBUG) 
 		3 + // /LIBPATH: ucrt, um, msvc
 		intermediateFiles.count +
 		config->additionalLibPaths.size() +
@@ -383,15 +383,65 @@ static bool8 Clang_LinkIntermediateFiles( compilerBackend_t *backend, const Arra
 
 	args.add( "kernel32.lib" );
 
-#if defined( _DEBUG )
-	args.add( "msvcrtd.lib" );
-	args.add( "vcruntimed.lib" );
-	args.add( "ucrtd.lib" );
-#else
-	args.add( "msvcrt.lib" );
-	args.add( "vcruntime.lib" );
-	args.add( "ucrt.lib" );
-#endif
+	bool8 isUserConfigBuild = false;
+	bool8 debugBuild = false;
+	bool8 hasDllRuntime = false;
+	For ( u32, i, 0, config->defines.size() ) {
+		if ( config->defines[i] == "BUILDER_DOING_USER_CONFIG_BUILD" ) {
+			isUserConfigBuild = true;
+		}
+		if ( config->defines[i] == "_DEBUG" ) {
+			 debugBuild = true; 
+		}
+		if ( config->defines[i] == "_DLL" ) {
+			hasDllRuntime = true;
+		}
+	}
+
+	if ( !isUserConfigBuild && config->binaryType != BINARY_TYPE_STATIC_LIBRARY ) {
+		if( debugBuild ) {
+			if ( hasDllRuntime ) {
+			args.add( "msvcrtd.lib" );
+			args.add( "msvcprtd.lib" );
+			args.add( "vcruntimed.lib" );
+			args.add( "ucrtd.lib" );
+			}
+			else {
+				args.add( "libcmtd.lib" );
+				args.add( "libcpmtd.lib" );
+				args.add( "libvcruntimed.lib" );
+				args.add( "libucrtd.lib" );
+			}
+		} else {
+			if ( hasDllRuntime ) {
+				args.add( "msvcrt.lib" );
+				args.add( "msvcprt.lib" );
+				args.add( "vcruntime.lib" );
+				args.add( "ucrt.lib" );
+			}
+			else {
+				args.add( "libcmt.lib" );
+				args.add( "libcpmt.lib" );
+				args.add( "libvcruntime.lib" );
+				args.add( "libucrt.lib" );
+			}
+		}
+	}
+	else if ( config->binaryType != BINARY_TYPE_STATIC_LIBRARY )
+	{
+		// libraries for user config
+		#if defined( _DEBUG )
+			args.add( "msvcrtd.lib" );
+			args.add( "msvcprtd.lib" );
+			args.add( "vcruntimed.lib" );
+			args.add( "ucrtd.lib" );
+		#else
+			args.add( "msvcrt.lib" );
+			args.add( "msvcprt.lib" );
+			args.add( "vcruntime.lib" );
+			args.add( "ucrt.lib" );
+		#endif
+	}
 
 	For ( u32, libIndex, 0, config->additionalLibs.size() ) {
 		args.add( tprintf( "%s%s", config->additionalLibs[libIndex].c_str(), GetFileExtensionFromBinaryType( BINARY_TYPE_STATIC_LIBRARY ) ) );

--- a/src/backend_msvc.cpp
+++ b/src/backend_msvc.cpp
@@ -223,7 +223,7 @@ static bool8 MSVC_CompileSourceFile(
 	return exitCode == 0;
 }
 
-static bool8 MSVC_LinkIntermediateFiles( compilerBackend_t *backend, const Array<const char *> &intermediateFiles, BuildConfig *config ) {
+static bool8 MSVC_LinkIntermediateFiles( compilerBackend_t *backend, const Array<const char *> &intermediateFiles, BuildConfig *config, const BuilderOptions *options ) {
 	assert( backend );
 	assert( config );
 
@@ -235,6 +235,7 @@ static bool8 MSVC_LinkIntermediateFiles( compilerBackend_t *backend, const Array
 		1 +	// link
 		1 +	// /lib or /shared
 		1 +	// /DEBUG
+		1 + // /NODEFAULTLIB
 		1 +	// /OUT:<name>
 		intermediateFiles.count +
 		msvcState->microsoftCoreLibPaths.size() +
@@ -254,6 +255,10 @@ static bool8 MSVC_LinkIntermediateFiles( compilerBackend_t *backend, const Array
 
 	if ( !config->removeSymbols ) {
 		args.add( "/DEBUG" );
+	}
+
+	if ( options && options->noDefaultLibs && config->binaryType != BINARY_TYPE_STATIC_LIBRARY ) {
+		args.add( "/NODEFAULTLIB" );
 	}
 
 	args.add( tprintf( "/OUT:%s", fullBinaryName ) );

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -1237,6 +1237,7 @@ int BuilderMain( const int firstArg, int argc, const char * const * argv ) {
 #else
 				"NDEBUG",
 #endif
+				"_DLL"
 			},
 			.additionalIncludes = {
 				// add the folder that builder lives in as an additional include path otherwise people have no real way of being able to include it

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -388,7 +388,7 @@ static s32 ShowUsage( const s32 exitCode ) {
 	return exitCode;
 }
 
-static buildResult_t BuildBinary( buildContext_t *context, BuildConfig *config, compilerBackend_t *compilerBackend, bool generateCompilationDatabase ) {
+static buildResult_t BuildBinary( buildContext_t *context, BuildConfig *config, compilerBackend_t *compilerBackend, const BuilderOptions *options ) {
 	// create binary folder
 	if ( !folder_create_if_it_doesnt_exist( config->binaryFolder.c_str() ) ) {
 		errorCode_t errorCode = get_last_error_code();
@@ -469,6 +469,7 @@ static buildResult_t BuildBinary( buildContext_t *context, BuildConfig *config, 
 		printf( "Compiling:\n" );
 	}
 
+	bool8 generateCompilationDatabase = options && options->generateCompilationDatabase;
 	if ( generateCompilationDatabase ) {
 		context->compilationDatabase.reserve( config->sourceFiles.size() );
 	}
@@ -536,7 +537,7 @@ static buildResult_t BuildBinary( buildContext_t *context, BuildConfig *config, 
 
 		printf( "\nLinking:\n" );
 
-		if ( !compilerBackend->LinkIntermediateFiles( compilerBackend, intermediateFiles, config ) ) {
+		if ( !compilerBackend->LinkIntermediateFiles( compilerBackend, intermediateFiles, config, options ) ) {
 			error( "Linking failed.\n" );
 			return BUILD_RESULT_FAILED;
 		}
@@ -1276,7 +1277,9 @@ int BuilderMain( const int firstArg, int argc, const char * const * argv ) {
 
 		userConfigFullBinaryName = BuildConfig_GetFullBinaryName( &userConfigBuildConfig );
 
-		userConfigBuildResult = BuildBinary( &context, &userConfigBuildConfig, &compilerBackend, false );
+		// Within build binary and check against the options checks for its existance, defaulting to false which is what the user config build wants for each option
+		// So just pass through nullptr when calling BuildBinary for the options build and it will work as expected
+		userConfigBuildResult = BuildBinary( &context, &userConfigBuildConfig, &compilerBackend, nullptr );
 
 		switch ( userConfigBuildResult ) {
 			case BUILD_RESULT_SUCCESS: {
@@ -1623,7 +1626,7 @@ int BuilderMain( const int firstArg, int argc, const char * const * argv ) {
 			{
 				float64 buildTimeStart = time_ms();
 
-				configBuildResults[configToBuildIndex] = BuildBinary( &context, config, &compilerBackend, options.generateCompilationDatabase );
+				configBuildResults[configToBuildIndex] = BuildBinary( &context, config, &compilerBackend, &options );
 
 				configBuildTimes[configToBuildIndex] = time_ms() - buildTimeStart;
 

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -1237,7 +1237,6 @@ int BuilderMain( const int firstArg, int argc, const char * const * argv ) {
 #else
 				"NDEBUG",
 #endif
-				"_DLL"
 			},
 			.additionalIncludes = {
 				// add the folder that builder lives in as an additional include path otherwise people have no real way of being able to include it

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -1581,6 +1581,10 @@ int BuilderMain( const int firstArg, int argc, const char * const * argv ) {
 				}
 			}
 
+			if( options.linkAgainstWindowsDynamicRuntime ) {
+				config->defines.push_back( "_DLL" );
+			}
+
 			// make all non-absolute additional include paths relative to the build source file
 			For ( u64, includeIndex, 0, config->additionalIncludes.size() ) {
 				const char *additionalInclude = config->additionalIncludes[includeIndex].c_str();

--- a/src/builder_local.h
+++ b/src/builder_local.h
@@ -82,7 +82,7 @@ struct compilerBackend_t {
 	bool8	( *Init )( compilerBackend_t *backend, const buildContext_t *context, const std::string &compilerPath, const std::string &compilerVersion );
 	void	( *Shutdown )( compilerBackend_t *backend );
 	bool8	( *CompileSourceFile )( compilerBackend_t *backend, buildContext_t *buildContext, BuildConfig *config, compilationCommandArchetype_t &commandArchetype, const char *sourceFile, bool recordCompilation );
-	bool8	( *LinkIntermediateFiles )( compilerBackend_t *backend, const Array<const char *> &intermediateFiles, BuildConfig *config );
+	bool8	( *LinkIntermediateFiles )( compilerBackend_t *backend, const Array<const char *> &intermediateFiles, BuildConfig *config, const BuilderOptions *options );
 	bool8	( *GetCompilationCommandArchetype )( const compilerBackend_t *backend, const BuildConfig *config, compilationCommandArchetype_t &outCmdArchetype );
 	void	( *GetIncludeDependenciesFromSourceFileBuild )( compilerBackend_t *backend, std::vector<std::string> &includeDependencies );
 	String	( *GetCompilerPath )( compilerBackend_t *backend );

--- a/tests/test_basic_stdlib/test_basic_stdlib.cpp
+++ b/tests/test_basic_stdlib/test_basic_stdlib.cpp
@@ -1,0 +1,14 @@
+// this is the "basic" test but requires the standard library, so we can test that Builder can link against the standard library without any special configuration
+// its meant to serve as the easiest, most minimal example of what builder can build
+// we should still be able to build programs with Builder without using any of the Builder-specific entry points
+
+#include <iostream>
+
+int main( int argc, char** argv ) {
+	( (void) argc );
+	( (void) argv );
+
+	std::cout << "libcmt.lib required." << std::endl;
+
+	return 0;
+}

--- a/tests/test_dynamic_runtime_linking/test_dynamic_runtime_linking.cpp
+++ b/tests/test_dynamic_runtime_linking/test_dynamic_runtime_linking.cpp
@@ -1,0 +1,29 @@
+
+#if BUILDER_DOING_USER_CONFIG_BUILD
+
+#include <builder.h>
+
+BUILDER_CALLBACK void SetBuilderOptions( BuilderOptions *options ) {
+  options->linkAgainstWindowsDynamicRuntime = true;
+}
+
+#else
+
+// _mbsdup is exported from ucrtbase.dll for backwards compatibility but was dropped from the
+// static runtime libs (libucrt.lib / libcmt.lib).  Unlike __imp_malloc or __imp___acrt_iob_func,
+// there is no static fallback for the linker to silently resolve against, so this produces a
+// hard LNK2001 error (not just a LNK4286 warning) if the static runtime is used.
+#pragma comment(linker, "/include:__imp__mbsdup")
+
+#include <iostream>
+
+int main( int argc, char** argv ) {
+	( (void) argc );
+	( (void) argv );
+
+  std::cout << "Dynamic runtime required." << std::endl;
+
+  return 0;
+}
+
+#endif // BUILDER_DOING_USER_CONFIG_BUILD

--- a/tests/tests_main.cpp
+++ b/tests/tests_main.cpp
@@ -253,6 +253,18 @@ TEMPER_INVOKE_PARAMETRIC_TEST( TestBuild, {
 } );
 
 TEMPER_INVOKE_PARAMETRIC_TEST( TestBuild, {
+	.rootDir			= "test_basic_stdlib",
+	.buildSourceFile	= "test_basic_stdlib.cpp",
+	.compilers			= COMPILER_DEFAULT,
+} );
+
+TEMPER_INVOKE_PARAMETRIC_TEST( TestBuild, {
+	.rootDir			= "test_dynamic_runtime_linking",
+	.buildSourceFile	= "test_dynamic_runtime_linking.cpp",
+	.compilers			= COMPILER_DEFAULT,
+} );
+
+TEMPER_INVOKE_PARAMETRIC_TEST( TestBuild, {
 	.rootDir			= "test_set_builder_options",
 	.buildSourceFile	= "test_set_builder_options.cpp",
 	.config				= "debug",


### PR DESCRIPTION
This will definitely need some polish but I have covered the weird lib detection that the C++ std library does. The way to check for the user build config isn't the nicest but lined up well with the other define checks.

There is some contention with how all of this should be used with clang, as it has the flag ms-runtime-lib which can be used like:
-fms-runtime-lib=dll_dbg
Which I believe would set for you both the _DLL and _DEBUG defines.

This is mostly assumed as compiling with both #define _DEBUG and #define _DLL with any combination of that flag set to:
dll_dbg
static_dbg
static
dll
Has no effect on the linking process.

Assuming we account for user stupidity the most robust check to know we are linking to the right libs would be:

Check for debug via define of _DEBUG (no conflicting NDEBUG will override this for lib check)
Check for debug via either of dll_dbg or static_dbg being set by the ms-runtime-lib flag
Check for dynamic linkage via define of _DLL
Check for dynamic linkage via either of dll_dbg or dll being set by the ms-runtime-lib flag
Then it's now simple to check against isDebug and isDynamicLinkage to accurately link against the windows libraries..... Fun.

The current commits outline the simplest approach that allows user flexibility across any used compiler as acts on the behaviour that determines the stdlib that it uses at compile time.